### PR TITLE
사이즈 구하기 테스트 추가 & 기능 구현

### DIFF
--- a/Composite/src/main/kotlin/Composite/Directory.kt
+++ b/Composite/src/main/kotlin/Composite/Directory.kt
@@ -1,7 +1,14 @@
 package Composite
 
 class Directory(name: String, size: Int = 0) : Entry(name, size) {
+
     private var childs = listOf<Entry>()
+
+    override var size: Int = 0
+        get() = childs.sumBy { it.size }
+        set(value) {
+            field = value
+        }
 
     override fun add(entry: Entry) {
         val copy = childs.toMutableList().apply {
@@ -18,5 +25,15 @@ class Directory(name: String, size: Int = 0) : Entry(name, size) {
                 it.printList("$parentsDir/$name")
             }
         }
+    }
+
+    override fun printSize(dir: String, size: Int) {
+
+        if (childs.isNotEmpty()) {
+            childs.map {
+                it.printSize("$dir/$name", this.size + size)
+            }
+        }
+        print("$dir/$name , size = ${childs.sumBy { it.size }}\n")
     }
 }

--- a/Composite/src/main/kotlin/Composite/Entry.kt
+++ b/Composite/src/main/kotlin/Composite/Entry.kt
@@ -1,6 +1,8 @@
 package Composite
 
-abstract class Entry(val name: String, val size: Int) {
+abstract class Entry(val name: String, size: Int) {
+    open var size = size
     abstract fun add(entry: Entry)
     abstract fun printList(parentsDir: String = "")
+    abstract fun printSize(dir: String = "", size: Int = 0)
 }

--- a/Composite/src/main/kotlin/Composite/File.kt
+++ b/Composite/src/main/kotlin/Composite/File.kt
@@ -1,10 +1,14 @@
 package Composite
 
-class File(name: String, size: Int) : Entry(name, size) {
+class File(name: String, size: Int = 0) : Entry(name, size) {
     override fun add(entry: Entry) {
     }
 
     override fun printList(parentsDir: String) {
         print("$parentsDir/$name")
+    }
+
+    override fun printSize(dir: String, size: Int) {
+        print("$dir/$name , size = ${this.size}\n")
     }
 }

--- a/Composite/src/test/kotlin/Composite/CompositeTest.kt
+++ b/Composite/src/test/kotlin/Composite/CompositeTest.kt
@@ -69,23 +69,6 @@ internal class CompositeTest {
                         "/root/tmp\n" +
                         "/root/usr\n"
         )
-
-        binDir.apply {
-            add(Directory("tmp"))
-        }
-        rootDir.printList("")
-
-        assertThat(outContent.toString()).isEqualTo(
-                "/root\n" +
-                        "/root/bin\n" +
-                        "/root/tmp\n" +
-                        "/root/usr\n" +
-                        "/root\n" +
-                        "/root/bin\n" +
-                        "/root/bin/tmp\n" +
-                        "/root/tmp\n" +
-                        "/root/usr\n"
-        )
     }
 
     @Test
@@ -116,6 +99,46 @@ internal class CompositeTest {
                         "/root/tmp\n" +
                         "/root/usr\n"
 
+        )
+    }
+
+    @Test
+    fun `사이즈 구하기 테스트`() {
+
+        val binDir = Directory("bin").apply {
+            add(File("test1.txt", 200))
+            add(File("test2.txt", 300))
+        }
+        val tmpDir = Directory("tmp").apply {
+            add(File("test1.txt", 1000))
+            add(File("test2.txt", 1000))
+        }
+        val usrDir = Directory("usr")
+
+        val rootDir = Directory("root").apply {
+            /**
+             * 디렉토리에 자식을 추가하는 연산을 동일하게 사용하기 위해서
+             * Directory class와 File class의 공통이 부분을 모아 인터페이스로 정의한다.
+             * */
+            add(File("memo.txt", 1000))
+
+            add(binDir)
+            add(tmpDir)
+            add(usrDir)
+        }
+
+        rootDir.printSize()
+
+        assertThat(outContent.toString()).isEqualTo(
+                "/root/memo.txt , size = 1000\n" +
+                        "/root/bin/test1.txt , size = 200\n" +
+                        "/root/bin/test2.txt , size = 300\n" +
+                        "/root/bin , size = 500\n" +
+                        "/root/tmp/test1.txt , size = 1000\n" +
+                        "/root/tmp/test2.txt , size = 1000\n" +
+                        "/root/tmp , size = 2000\n" +
+                        "/root/usr , size = 0\n" +
+                        "/root , size = 3500\n"
         )
     }
 }


### PR DESCRIPTION
디렉터리와 파일의 사이즈를 출력하는 테스트를 작성하고 기능을 구현했다. 
디렉터리는 자식 디렉터리 또는 파일의 사이즈를 모두 합한 값을 사이즈를 출력하고 파일을 자신의 사이즈를 출력한다. 어느 디렉터리 또는 파일의 사이즈인지 알기 위해 경로도 같이 출력하게 하였다.